### PR TITLE
chore: follow stylelint recommendation for Expected shorthand property

### DIFF
--- a/packages/ui/src/components/View/SourceTargetView.scss
+++ b/packages/ui/src/components/View/SourceTargetView.scss
@@ -14,8 +14,7 @@
   &__source-panel-main {
     height: 100%;
     max-height: 100%;
-    overflow-y: auto;
-    overflow-x: clip;
+    overflow: clip auto;
   }
 
   &__line-blank {
@@ -49,4 +48,3 @@
     padding-bottom: 0.5rem;
   }
 }
-


### PR DESCRIPTION
"overflow"  declaration-block-no-redundant

to fix stylelint issues reported during build on PR https://github.com/KaotoIO/kaoto/pull/1700