### PR TITLE
fix(DataMapper): change applyFieldSubstitution to accept QName

### DIFF
--- a/packages/ui/src/models/datamapper/document.ts
+++ b/packages/ui/src/models/datamapper/document.ts
@@ -43,6 +43,7 @@ export type IParentType = IDocument | IField;
  */
 export interface IOriginalFieldState {
   name: string;
+  displayName: string;
   namespaceURI: string | null;
   namespacePrefix: string | null;
   type: Types;

--- a/packages/ui/src/services/document-util.service.ts
+++ b/packages/ui/src/services/document-util.service.ts
@@ -74,6 +74,7 @@ export class DocumentUtilService {
   private static captureOriginalFieldState(field: IField): IOriginalFieldState {
     return {
       name: field.name,
+      displayName: field.displayName,
       namespaceURI: field.namespaceURI,
       namespacePrefix: field.namespacePrefix,
       type: field.type,
@@ -128,6 +129,7 @@ export class DocumentUtilService {
   static applySubstitutionToField(field: IField, info: IFieldSubstituteInfo): void {
     field.originalField ??= DocumentUtilService.captureOriginalFieldState(field);
     field.name = info.name;
+    field.displayName = info.name;
     field.namespaceURI = info.namespaceURI;
     field.namespacePrefix = info.namespacePrefix;
     field.type = info.type;

--- a/packages/ui/src/services/field-type-override.service.test.ts
+++ b/packages/ui/src/services/field-type-override.service.test.ts
@@ -9,6 +9,7 @@ import {
 } from '../models/datamapper';
 import { NS_XML_SCHEMA } from '../models/datamapper/standard-namespaces';
 import { FieldOverrideVariant } from '../models/datamapper/types';
+import { QName } from '../xml-schema-ts/QName';
 import {
   getFieldSubstitutionNoNsXsd,
   getFieldSubstitutionXsd,
@@ -896,7 +897,7 @@ describe('FieldTypeOverrideService', () => {
       const namespaceMap = { sub: NS_SUBSTITUTION };
       const abstractAnimalField = doc.fields[0];
 
-      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, 'sub:Cat', namespaceMap);
+      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, new QName(NS_SUBSTITUTION, 'Cat'), namespaceMap);
 
       expect(doc.definition.fieldSubstitutions).toHaveLength(1);
       expect(doc.definition.fieldSubstitutions![0].name).toBe('sub:Cat');
@@ -910,7 +911,7 @@ describe('FieldTypeOverrideService', () => {
       const abstractAnimalField = doc.fields[0];
       const originalName = abstractAnimalField.name;
 
-      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, 'sub:Cat', namespaceMap);
+      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, new QName(NS_SUBSTITUTION, 'Cat'), namespaceMap);
       expect(abstractAnimalField.typeOverride).toBe(FieldOverrideVariant.SUBSTITUTION);
 
       FieldTypeOverrideService.revertFieldSubstitution(doc, abstractAnimalField, namespaceMap);
@@ -939,7 +940,7 @@ describe('FieldTypeOverrideService', () => {
       );
 
       expect(() => {
-        FieldTypeOverrideService.applyFieldSubstitution(jsonDocument, field, 'sub:Cat', {});
+        FieldTypeOverrideService.applyFieldSubstitution(jsonDocument, field, new QName(null, 'Cat'), {});
       }).not.toThrow();
     });
 
@@ -948,8 +949,8 @@ describe('FieldTypeOverrideService', () => {
       const namespaceMap = { sub: NS_SUBSTITUTION };
       const abstractAnimalField = doc.fields[0];
 
-      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, 'sub:Cat', namespaceMap);
-      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, 'sub:Dog', namespaceMap);
+      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, new QName(NS_SUBSTITUTION, 'Cat'), namespaceMap);
+      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, new QName(NS_SUBSTITUTION, 'Dog'), namespaceMap);
 
       expect(doc.definition.fieldSubstitutions).toHaveLength(1);
       expect(doc.definition.fieldSubstitutions![0].name).toBe('sub:Dog');
@@ -972,7 +973,7 @@ describe('FieldTypeOverrideService', () => {
       const abstractAnimalField = doc.fields[0];
       const originalName = abstractAnimalField.name;
 
-      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, 'Cat', {});
+      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, new QName(null, 'Cat'), {});
 
       expect(doc.definition.fieldSubstitutions).toHaveLength(1);
       expect(doc.definition.fieldSubstitutions![0].name).toBe('Cat');
@@ -987,7 +988,7 @@ describe('FieldTypeOverrideService', () => {
       const abstractAnimalField = doc.fields[0];
       const originalName = abstractAnimalField.name;
 
-      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, 'Cat', {});
+      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, new QName(null, 'Cat'), {});
       FieldTypeOverrideService.revertFieldSubstitution(doc, abstractAnimalField, {});
 
       expect(abstractAnimalField.name).toBe(originalName);
@@ -1010,8 +1011,8 @@ describe('FieldTypeOverrideService', () => {
       const doc = createNoNsSubstitutionDoc();
       const abstractAnimalField = doc.fields[0];
 
-      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, 'Cat', {});
-      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, 'Dog', {});
+      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, new QName(null, 'Cat'), {});
+      FieldTypeOverrideService.applyFieldSubstitution(doc, abstractAnimalField, new QName(null, 'Dog'), {});
 
       expect(doc.definition.fieldSubstitutions).toHaveLength(1);
       expect(doc.definition.fieldSubstitutions![0].name).toBe('Dog');

--- a/packages/ui/src/services/field-type-override.service.ts
+++ b/packages/ui/src/services/field-type-override.service.ts
@@ -560,6 +560,7 @@ export class FieldTypeOverrideService {
     );
     if (field.originalField) {
       field.name = field.originalField.name;
+      field.displayName = field.originalField.displayName;
       field.namespaceURI = field.originalField.namespaceURI;
       field.namespacePrefix = field.originalField.namespacePrefix;
       field.type = field.originalField.type;

--- a/packages/ui/src/services/field-type-override.service.ts
+++ b/packages/ui/src/services/field-type-override.service.ts
@@ -1,6 +1,7 @@
 import { DocumentDefinition, IDocument, IField, PrimitiveDocument } from '../models/datamapper/document';
 import { IChoiceSelection, IFieldSubstitution, IFieldTypeOverride } from '../models/datamapper/metadata';
 import { FieldOverrideVariant, IFieldTypeInfo, Types } from '../models/datamapper/types';
+import { QName } from '../xml-schema-ts/QName';
 import { DocumentUtilService, ParseTypeOverrideFn } from './document-util.service';
 import { JsonSchemaDocument } from './json-schema-document.model';
 import { JsonSchemaDocumentService } from './json-schema-document.service';
@@ -484,6 +485,13 @@ export class FieldTypeOverrideService {
     );
   }
 
+  private static ensureNamespaceRegistered(namespaceURI: string | null, namespaceMap: Record<string, string>): void {
+    if (!namespaceURI) return;
+    if (Object.values(namespaceMap).includes(namespaceURI)) return;
+    const prefix = DocumentUtilService.generateNamespacePrefix(namespaceMap);
+    namespaceMap[prefix] = namespaceURI;
+  }
+
   /**
    * Apply an element substitution to a field in a document.
    *
@@ -495,21 +503,24 @@ export class FieldTypeOverrideService {
    *
    * @param document - The document containing the field (must be XmlSchemaDocument)
    * @param field - The field to substitute
-   * @param substituteElementQName - The substitute element name in `prefix:localName` form
+   * @param substituteElement - QName identifying the substitute element
    * @param namespaceMap - Namespace prefix to URI mapping
    */
   static applyFieldSubstitution(
     document: IDocument,
     field: IField,
-    substituteElementQName: string,
+    substituteElement: QName,
     namespaceMap: Record<string, string>,
   ): void {
     if (!(document instanceof XmlSchemaDocument)) return;
+    const nsURI = substituteElement.getNamespaceURI() || null;
+    FieldTypeOverrideService.ensureNamespaceRegistered(nsURI, namespaceMap);
+    const substituteName = buildPrefixedName(substituteElement.getLocalPart()!, nsURI, namespaceMap);
     const schemaPath = SchemaPathService.buildOriginal(field, namespaceMap);
     const origName = field.originalField?.name ?? field.name;
     const origNsURI = field.originalField?.namespaceURI ?? field.namespaceURI;
     const originalName = buildPrefixedName(origName, origNsURI, namespaceMap);
-    const entry: IFieldSubstitution = { schemaPath, name: substituteElementQName, originalName };
+    const entry: IFieldSubstitution = { schemaPath, name: substituteName, originalName };
     document.definition.fieldSubstitutions ??= [];
     const existingIndex = document.definition.fieldSubstitutions.findIndex((s) => s.schemaPath === schemaPath);
     if (existingIndex >= 0) {


### PR DESCRIPTION
## Summary
- Change `applyFieldSubstitution` parameter from `string` to `QName` to make namespace handling self-contained
- Add `ensureNamespaceRegistered` to register missing namespace prefixes before building prefixed name
- Prevents silent substitution resolution failures when namespace is not yet in the namespace map

## Test plan
- [x] All 48 `field-type-override.service` tests pass
- [x] New test: `should register missing namespace and prefix the key when namespace is not in map`